### PR TITLE
Wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ On Linux, the application uses **Evdev** to bypass compositor restrictions and *
 **Manual Setup**:
 
 1. **Dependencies**: `sudo apt-get install build-essential python3-dev libevdev-dev python3-tk xdotool`
-2. **Permissions**: Add your user to the `input` and `uinput` groups.
-3. **UDev Rules**: Ensure `/dev/uinput` is accessible. You can use the helper script:
+2. **Permissions**: The app requires access to `/dev/uinput` and input devices. We use `udev` rules to grant this securely to the current user (via `uaccess` tag).
+3. **UDev Rules**: Run the helper script to install the rules:
    ```bash
    ./scripts/fix_wayland_permissions.sh
    ```
-4. **Login**: You **must log out and log back in** (or restart) for group changes to take effect. If you're in a hurry, run `newgrp input` in your terminal.
+4. **Apply Changes**: You may need to **reboot or re-login** for these `udev` rules to apply to existing devices.
 
 ### 3. Python Dependencies
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,44 +1,13 @@
-# Release v0.0.4
+# Release v0.0.5
 
-## 🚀 Wayland Support & Stability
+### Improvements & Fixes
 
-This release brings full compatibility for Wayland sessions on Linux, removing previous input simulation restrictions.
-
-- **Native Wayland Support**: Implemented `EvdevEngine` to bypass security restrictions via `/dev/input` and `/dev/uinput`.
-- **Absolute Mouse Synchronization**: Implemented hardware-level injection for both moves and clicks. This ensures pixel-perfect accuracy on high-resolution Wayland environments.
-- **Automatic Engine Selection**: Intelligent fallback between `evdev` (Wayland/Linux) and `pynput` (X11/Windows).
-- **Enhanced Stability**: Added a "Heartbeat" mechanism to automatically restart input listeners if they become unresponsive.
-
-## 🛠 Enhancements
-
-- **Input Handling**: Abstracted input logic into a flexible `InputEngine` architecture.
-- **Project Organization**: Cleaned up the `scripts/` directory and moved essential verification tools to a new `tests/` directory.
-- **Build System**: Resolved Linux binary build failures by including `fix_wayland_permissions.sh` script in the distribution.
-
-## 📦 Installation & Setup (Linux)
-
-**Important**: Wayland support requires kernel-level permissions.
-
-1. **Install Dependencies**:
-
-   ```bash
-   # Sets up libraries, groups, and udev rules
-   ./scripts/install_linux.sh
-   ```
-
-2. **Grant Permissions**:
-   If the installer didn't handle it or you prefer manual setup, run:
-
-   ```bash
-   ./scripts/fix_wayland_permissions.sh
-   ```
-
-   **Log out and back in** for group changes to stay active.
-
-3. **Run**:
-   ```bash
-   # For the pre-compiled release:
-   cd dist/release
-   sudo ./install.sh
-   ./XvG-AutoKeybind
-   ```
+- **Macro Reliability**:
+  - Macros now wait for physical keys to be released before firing (1.0s timeout) to prevent modifier interference (e.g., unintended combinations like Ctrl+C when holding Ctrl).
+  - Explicit software release of modifiers (Shift, Ctrl, Alt, Cmd) before each macro execution.
+- **Keybind Engine**:
+  - Moved bind checks to the key release event for more consistent behavior.
+- **Wayland / Linux Setup**:
+  - Shifted to `uaccess`-based `udev` rules for device permissions, removing the need for manually managing `input`/`uinput` group membership.
+- **Input Engine**:
+  - Added `get_current_position` method to `PynputEngine` with fallback to `pyautogui`.

--- a/autokeybind.py
+++ b/autokeybind.py
@@ -1359,9 +1359,15 @@ class KeybindApp:
             return
             
         try:
-            # Safety Delay: Allow user to release trigger keys (e.g. Alt, Ctrl)
-            # This prevents the physical keys from interfering with the virtual injection (e.g. Alt+Space issues)
-            time.sleep(0.3)
+            # wait for physical key release (up to 1.0s)
+            # This prevents modifier interference (e.g. holding Ctrl while macro types 'c' -> Ctrl+C)
+            start_wait = time.time()
+            while self.current_pressed_keys and (time.time() - start_wait) < 1.0:
+                 time.sleep(0.05)
+                 
+            # Force release modifiers via software just in case
+            if self.input_engine:
+                 self.input_engine.release_all_modifiers()
             
             # Detect Data Structure Type
             if isinstance(bind_data, list):

--- a/autokeybind.py
+++ b/autokeybind.py
@@ -1311,10 +1311,12 @@ class KeybindApp:
             self.emergency_stop()
             return
 
-        self.check_and_perform_action()
-
     def on_key_release(self, key):
         # print(f"DEBUG: Key Released: {key}")
+        
+        # Check for bind BEFORE removing the key
+        self.check_and_perform_action()
+
         if key in self.current_pressed_keys:
             self.current_pressed_keys.remove(key)
 

--- a/input_engine.py
+++ b/input_engine.py
@@ -139,6 +139,15 @@ class PynputEngine(InputEngine):
         import pyautogui
         pyautogui.click(x, y, button=button)
 
+    def get_current_position(self):
+        """Returns the current mouse position using pynput Controller."""
+        try:
+            from pynput.mouse import Controller as MouseController
+            return MouseController().position
+        except:
+             import pyautogui
+             return pyautogui.position()
+             
     def simulation_move(self, x: int, y: int):
         import pyautogui
         pyautogui.moveTo(x, y)

--- a/input_engine.py
+++ b/input_engine.py
@@ -66,6 +66,11 @@ class InputEngine(abc.ABC):
     @abc.abstractmethod
     def simulation_key(self, key_string: str):
         pass
+
+    @abc.abstractmethod
+    def release_all_modifiers(self):
+        """Releases common modifier keys to ensure clean state."""
+        pass
         
     def is_healthy(self):
         """Returns True if the engine is running properly."""
@@ -160,6 +165,20 @@ class PynputEngine(InputEngine):
                 self.keyboard_controller.release(key_string)
         except Exception as e:
             print(f"[Pynput] Error simulating key '{key_string}': {e}")
+
+    def release_all_modifiers(self):
+        """Force release modifiers for Pynput."""
+        modifiers = [
+            Key.shift, Key.shift_r,
+            Key.ctrl, Key.ctrl_r,
+            Key.alt, Key.alt_r,
+            Key.cmd, Key.cmd_r
+        ]
+        for key in modifiers:
+            try:
+                self.keyboard_controller.release(key)
+            except:
+                pass
 
 
 class EvdevEngine(InputEngine):


### PR DESCRIPTION
# Release v0.0.5

### Improvements & Fixes

- **Macro Reliability**:
  - Macros now wait for physical keys to be released before firing (1.0s timeout) to prevent modifier interference (e.g., unintended combinations like Ctrl+C when holding Ctrl).
  - Explicit software release of modifiers (Shift, Ctrl, Alt, Cmd) before each macro execution.
- **Keybind Engine**:
  - Moved bind checks to the key release event for more consistent behavior.
- **Wayland / Linux Setup**:
  - Shifted to `uaccess`-based `udev` rules for device permissions, removing the need for manually managing `input`/`uinput` group membership.
- **Input Engine**:
  - Added `get_current_position` method to `PynputEngine` with fallback to `pyautogui`.
